### PR TITLE
early-init added, straight package manager fix

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -1,0 +1,1 @@
+(setq package-enable-at-startup nil)


### PR DESCRIPTION
Disabled default PM (Package Manager) to work with Straight